### PR TITLE
Element #enable_probe_controls does not exist

### DIFF
--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -510,8 +510,6 @@ function closePreferencesDialog() {
             if (id('enable_lock_UI').checked != (preferenceslist[0].enable_lock_UI === 'true')) modified = true;
             //Monitor connection
             if (id('enable_ping').checked != (preferenceslist[0].enable_ping === 'true')) modified = true;
-            //probe
-            if (id('enable_probe_controls').checked != (preferenceslist[0].enable_probe === 'true')) modified = true;
             //control panel
             if (id('show_control_panel').checked != (preferenceslist[0].enable_control_panel === 'true')) modified = true;
             //grbl panel


### PR DESCRIPTION
Element with id = 'enable_probe_controls' does not exist. So it is impossible to close div 'Prefereneces' because it cause the error: Uncaught TypeError: Cannot read properties of null (reading 'checked')
    at closePreferencesDialog